### PR TITLE
video_core: Restore Frame Skip functionality

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/IntSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/IntSetting.kt
@@ -49,6 +49,7 @@ enum class IntSetting(
     PRIORITY_BOOST("priority_boost", Settings.SECTION_CORE, 1),
     DEBUG_RENDERER("renderer_debug", Settings.SECTION_DEBUG, 0),
     TEXTURE_FILTER("texture_filter", Settings.SECTION_RENDERER, 0),
+    FRAME_SKIP("frame_skip", Settings.SECTION_RENDERER, 0),
     USE_FRAME_LIMIT("use_frame_limit", Settings.SECTION_RENDERER, 1);
 
     override var int: Int = defaultValue

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -792,6 +792,18 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                 )
             )
 
+            add(
+                SingleChoiceSetting(
+                    IntSetting.FRAME_SKIP,
+                    R.string.frame_skip_name,
+                    R.string.frame_skip_description,
+                    R.array.frameSkipNames,
+                    R.array.frameSkipValues,
+                    IntSetting.FRAME_SKIP.key,
+                    IntSetting.FRAME_SKIP.defaultValue
+                )
+            )
+
             add(HeaderSetting(R.string.stereoscopy))
             add(
                 SingleChoiceSetting(

--- a/src/android/app/src/main/jni/config.cpp
+++ b/src/android/app/src/main/jni/config.cpp
@@ -154,6 +154,7 @@ void Config::ReadValues() {
     ReadSetting("Renderer", Settings::values.use_vsync_new);
     ReadSetting("Renderer", Settings::values.texture_filter);
     ReadSetting("Renderer", Settings::values.texture_sampling);
+    ReadSetting("Renderer", Settings::values.frame_skip);
 
     // Work around to map Android setting for enabling the frame limiter to the format Citra expects
     if (sdl2_config->GetBoolean("Renderer", "use_frame_limit", true)) {

--- a/src/android/app/src/main/res/values/arrays.xml
+++ b/src/android/app/src/main/res/values/arrays.xml
@@ -183,6 +183,20 @@
         <item>5</item>
     </integer-array>
 
+    <string-array name="frameSkipNames">
+        <item>@string/disabled</item>
+        <item>@string/x2</item>
+        <item>@string/x4</item>
+        <item>@string/x8</item>
+    </string-array>
+
+    <integer-array name="frameSkipValues">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+    </integer-array>
+
     <string-array name="themeModeEntries">
         <item>@string/theme_mode_follow_system</item>
         <item>@string/theme_mode_light</item>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -245,6 +245,8 @@
     <string name="frame_limit_enable_description">When enabled, emulation speed will be limited to a specified percentage of normal speed.</string>
     <string name="frame_limit_slider">Limit Speed Percent</string>
     <string name="frame_limit_slider_description">Specifies the percentage to limit emulation speed. With the default of 100% emulation will be limited to normal speed. Values higher or lower will increase or decrease the speed limit.</string>
+    <string name="frame_skip_name">Frame Skip</string>
+    <string name="frame_skip_description">The amount of frames to skip. Best matched with the Enable VSync and Enable Real Time Audio options.</string>
     <string name="internal_resolution">Internal Resolution</string>
     <string name="internal_resolution_description">Specifies the resolution used to render at. A high resolution will improve visual quality a lot but is also quite heavy on performance and might cause glitches in certain games.</string>
     <string name="internal_resolution_setting_1x">Native (400x240)</string>
@@ -589,6 +591,12 @@
     <string name="scaleforce">ScaleForce</string>
     <string name="xbrz">xBRZ</string>
     <string name="mmpx">MMPX</string>
+
+    <!-- Frame skip names -->
+    <string name="disabled">Disabled</string>
+    <string name="x2">x2</string>
+    <string name="x4">x4</string>
+    <string name="x8">x8</string>
 
     <!-- Sound output modes -->
     <string name="mono">Mono</string>

--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -129,6 +129,7 @@ void Config::ReadValues() {
 
     // Core
     ReadSetting("Core", Settings::values.use_cpu_jit);
+    ReadSetting("Core", Settings::values.frame_skip);
     ReadSetting("Core", Settings::values.cpu_clock_percentage);
     ReadSetting("Core", Settings::values.raise_cpu_ticks);
     ReadSetting("Core", Settings::values.core_downcount_hack);
@@ -151,6 +152,7 @@ void Config::ReadValues() {
     ReadSetting("Renderer", Settings::values.resolution_factor);
     ReadSetting("Renderer", Settings::values.use_disk_shader_cache);
     ReadSetting("Renderer", Settings::values.frame_limit);
+    ReadSetting("Renderer", Settings::values.frame_skip);
     ReadSetting("Renderer", Settings::values.use_vsync_new);
     ReadSetting("Renderer", Settings::values.texture_filter);
     ReadSetting("Renderer", Settings::values.texture_sampling);

--- a/src/citra/default_ini.h
+++ b/src/citra/default_ini.h
@@ -91,6 +91,10 @@ udp_pad_index=
 # 0: Interpreter (slow), 1 (default): JIT (fast)
 use_cpu_jit =
 
+# The amount of frames to skip.
+# 0 (default): No frameskip, 1:  skip 1 frame, 2: skip 2 frames, etc.
+frame_skip =
+
 # Change the Clock Frequency of the emulated 3DS CPU.
 # Underclocking can increase the performance of the game at the risk of freezing.
 # Overclocking may fix lag that happens on console, but also comes with the risk of freezing.

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -461,6 +461,7 @@ void Config::ReadCoreValues() {
 
     if (global) {
         ReadBasicSetting(Settings::values.use_cpu_jit);
+        ReadBasicSetting(Settings::values.frame_skip);
         ReadBasicSetting(Settings::values.delay_start_for_lle_modules);
     }
 
@@ -667,6 +668,7 @@ void Config::ReadRendererValues() {
     ReadGlobalSetting(Settings::values.use_vsync_new);
     ReadGlobalSetting(Settings::values.resolution_factor);
     ReadGlobalSetting(Settings::values.frame_limit);
+    ReadGlobalSetting(Settings::values.frame_skip);
 
     ReadGlobalSetting(Settings::values.bg_red);
     ReadGlobalSetting(Settings::values.bg_green);
@@ -1014,6 +1016,7 @@ void Config::SaveCoreValues() {
 
     if (global) {
         WriteBasicSetting(Settings::values.use_cpu_jit);
+        WriteBasicSetting(Settings::values.frame_skip);
         WriteBasicSetting(Settings::values.delay_start_for_lle_modules);
     }
 
@@ -1182,6 +1185,7 @@ void Config::SaveRendererValues() {
     WriteGlobalSetting(Settings::values.use_vsync_new);
     WriteGlobalSetting(Settings::values.resolution_factor);
     WriteGlobalSetting(Settings::values.frame_limit);
+    WriteGlobalSetting(Settings::values.frame_skip);
 
     WriteGlobalSetting(Settings::values.bg_red);
     WriteGlobalSetting(Settings::values.bg_green);

--- a/src/citra_qt/configuration/configure_enhancements.cpp
+++ b/src/citra_qt/configuration/configure_enhancements.cpp
@@ -64,6 +64,10 @@ void ConfigureEnhancements::SetConfiguration() {
                                           !Settings::values.texture_filter.UsingGlobal());
         ConfigurationShared::SetPerGameSetting(ui->layout_combobox,
                                                &Settings::values.layout_option);
+        ConfigurationShared::SetPerGameSetting(ui->frame_skip_combobox,
+                                               &Settings::values.frame_skip);
+        ConfigurationShared::SetHighlight(ui->widget_frame_skip,
+                                          !Settings::values.frame_skip.UsingGlobal());
     } else {
         ui->resolution_factor_combobox->setCurrentIndex(
             Settings::values.resolution_factor.GetValue());
@@ -71,6 +75,8 @@ void ConfigureEnhancements::SetConfiguration() {
             static_cast<int>(Settings::values.layout_option.GetValue()));
         ui->texture_filter_combobox->setCurrentIndex(
             static_cast<int>(Settings::values.texture_filter.GetValue()));
+        ui->frame_skip_combobox->setCurrentIndex(
+            static_cast<int>(Settings::values.frame_skip.GetValue()));
     }
 
     ui->render_3d_combobox->setCurrentIndex(
@@ -159,6 +165,7 @@ void ConfigureEnhancements::ApplyConfiguration() {
                                              swap_screen);
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.upright_screen,
                                              ui->toggle_upright_screen, upright_screen);
+    ConfigurationShared::ApplyPerGameSetting(&Settings::values.frame_skip, ui->frame_skip_combobox);
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.dump_textures,
                                              ui->toggle_dump_textures, dump_textures);
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.custom_textures,
@@ -178,6 +185,7 @@ void ConfigureEnhancements::SetupPerGameUI() {
     if (Settings::IsConfiguringGlobal()) {
         ui->widget_resolution->setEnabled(Settings::values.resolution_factor.UsingGlobal());
         ui->widget_texture_filter->setEnabled(Settings::values.texture_filter.UsingGlobal());
+        ui->widget_frame_skip->setEnabled(Settings::values.frame_skip.UsingGlobal());
         ui->toggle_linear_filter->setEnabled(Settings::values.filter_mode.UsingGlobal());
         ui->toggle_swap_screen->setEnabled(Settings::values.swap_screen.UsingGlobal());
         ui->toggle_upright_screen->setEnabled(Settings::values.upright_screen.UsingGlobal());
@@ -220,4 +228,8 @@ void ConfigureEnhancements::SetupPerGameUI() {
     ConfigurationShared::SetColoredComboBox(
         ui->layout_combobox, ui->widget_layout,
         static_cast<int>(Settings::values.layout_option.GetValue(true)));
+
+    ConfigurationShared::SetColoredComboBox(
+        ui->frame_skip_combobox, ui->widget_frame_skip,
+        static_cast<int>(Settings::values.frame_skip.GetValue(true)));
 }

--- a/src/citra_qt/configuration/configure_enhancements.ui
+++ b/src/citra_qt/configuration/configure_enhancements.ui
@@ -204,6 +204,58 @@
         </layout>
        </widget>
       </item>
+      <item>
+       <widget class="QWidget" name="widget_frame_skip" native="true">
+        <layout class="QHBoxLayout" name="horizontalLayout_4">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="frame_skip_label">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The number of frames to skip.&lt;/p&gt;&lt;p&gt;WARNING: Results may vary depending on using the Vulkan or OpenGL renderer. If set too high, the screen may not render at all. Use with caution.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>Frame Skip</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="frame_skip_combobox">
+           <item>
+            <property name="text">
+             <string>Disabled</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>x2</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>x4</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>x8</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -254,7 +306,7 @@
        </layout>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_7">
+       <layout class="QHBoxLayout" name="horizontalLayout_6">
         <item>
          <widget class="QLabel" name="label_3">
           <property name="text">
@@ -281,7 +333,7 @@
        </layout>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_9">
+       <layout class="QHBoxLayout" name="horizontalLayout_7">
         <item>
          <widget class="QLabel" name="label_6">
           <property name="text">
@@ -532,6 +584,7 @@
   <tabstop>toggle_linear_filter</tabstop>
   <tabstop>shader_combobox</tabstop>
   <tabstop>texture_filter_combobox</tabstop>
+  <tabstop>frame_skip_combobox</tabstop>
   <tabstop>render_3d_combobox</tabstop>
   <tabstop>factor_3d</tabstop>
   <tabstop>mono_rendering_eye</tabstop>

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -101,6 +101,7 @@ void LogSettings() {
     log_setting("Renderer_UseShaderJit", values.use_shader_jit.GetValue());
     log_setting("Renderer_UseResolutionFactor", values.resolution_factor.GetValue());
     log_setting("Renderer_FrameLimit", values.frame_limit.GetValue());
+    log_setting("Renderer_FrameSkip", values.frame_skip.GetValue());
     log_setting("Renderer_VSyncNew", values.use_vsync_new.GetValue());
     log_setting("Renderer_PostProcessingShader", values.pp_shader_name.GetValue());
     log_setting("Renderer_FilterMode", values.filter_mode.GetValue());
@@ -206,6 +207,7 @@ void RestoreGlobalState(bool is_powered_on) {
     values.use_vsync_new.SetGlobal(true);
     values.resolution_factor.SetGlobal(true);
     values.frame_limit.SetGlobal(true);
+    values.frame_skip.SetGlobal(true);
     values.texture_filter.SetGlobal(true);
     values.texture_sampling.SetGlobal(true);
     values.layout_option.SetGlobal(true);

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -430,6 +430,7 @@ struct Values {
 
     // Core
     Setting<bool> use_cpu_jit{true, "use_cpu_jit"};
+    SwitchableSetting<u8> frame_skip{0, "frame_skip"};
     SwitchableSetting<s32, true> cpu_clock_percentage{100, 5, 400, "cpu_clock_percentage"};
     SwitchableSetting<bool> is_new_3ds{true, "is_new_3ds"};
     SwitchableSetting<bool> lle_applets{false, "lle_applets"};

--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -3,7 +3,9 @@
 // Refer to the license.txt file included.
 
 #include "common/archives.h"
+#include "common/common_types.h"
 #include "common/profiling.h"
+#include "common/settings.h"
 #include "core/core.h"
 #include "core/core_timing.h"
 #include "core/hle/service/gsp/gsp_gpu.h"
@@ -21,6 +23,13 @@ namespace VideoCore {
 
 constexpr VAddr VADDR_LCD = 0x1ED02000;
 constexpr VAddr VADDR_GPU = 0x1EF00000;
+
+// Frame skip
+/// True if the current frame was skipped
+bool g_skip_frame;
+/// True if the last frame was skipped
+static bool last_skip_frame;
+static u8 frame_count;
 
 struct GPU::Impl {
     Core::Timing& timing;
@@ -48,6 +57,9 @@ struct GPU::Impl {
 GPU::GPU(Core::System& system, Frontend::EmuWindow& emu_window,
          Frontend::EmuWindow* secondary_window)
     : impl{std::make_unique<Impl>(system, emu_window, secondary_window)} {
+    last_skip_frame = false;
+    g_skip_frame = false;
+    frame_count = 0;
     impl->vblank_event = impl->timing.RegisterEvent(
         "GPU::VBlankCallback",
         [this](uintptr_t user_data, s64 cycles_late) { VBlankCallback(user_data, cycles_late); });
@@ -403,8 +415,25 @@ void GPU::MemoryTransfer() {
 }
 
 void GPU::VBlankCallback(std::uintptr_t user_data, s64 cycles_late) {
-    // Present renderered frame.
-    impl->renderer->SwapBuffers();
+    /// Frame Skip
+    frame_count++;
+    last_skip_frame = g_skip_frame;
+    g_skip_frame = (frame_count & Settings::values.frame_skip.GetValue()) != 0;
+
+    // Swap buffers based on the frameskip mode, which is a little bit tricky. When
+    // a frame is being skipped, nothing is being rendered to the internal framebuffer(s).
+    // So, we should only swap frames if the last frame was rendered. The rules are:
+    //  - If frameskip == 0 (disabled), always swap buffers
+    //  - If frameskip == 1, swap buffers every other frame (starting from the first frame)
+    //  - If frameskip > 1, swap buffers every frameskip^n frames (starting from the second frame)
+    if ((((Settings::values.frame_skip.GetValue() != 1) ^ last_skip_frame) &&
+         last_skip_frame != g_skip_frame) ||
+        Settings::values.frame_skip.GetValue() == 0) {
+
+        // Present renderered frame.
+        impl->renderer->SwapBuffers();
+        frame_count = 0;
+    }
 
     // Signal to GSP that GPU interrupt has occurred
     impl->signal_interrupt(Service::GSP::InterruptId::PDC0);

--- a/src/video_core/gpu.h
+++ b/src/video_core/gpu.h
@@ -38,6 +38,9 @@ constexpr u64 FRAME_TICKS = 4481136ull;
 class GraphicsDebugger;
 class RendererBase;
 
+// Frame skip
+extern bool g_skip_frame;
+
 /**
  * The GPU class is the high level interface to the video_core for core services.
  */

--- a/src/video_core/pica/pica_core.cpp
+++ b/src/video_core/pica/pica_core.cpp
@@ -10,6 +10,7 @@
 #include "core/core.h"
 #include "core/memory.h"
 #include "video_core/debug_utils/debug_utils.h"
+#include "video_core/gpu.h"
 #include "video_core/pica/pica_core.h"
 #include "video_core/pica/vertex_loader.h"
 #include "video_core/rasterizer_interface.h"
@@ -53,6 +54,7 @@ PicaCore::PicaCore(Memory::MemorySystem& memory_, std::shared_ptr<DebugContext> 
 PicaCore::~PicaCore() = default;
 
 void PicaCore::InitializeRegs() {
+
     auto& framebuffer_top = regs.framebuffer_config[0];
     auto& framebuffer_sub = regs.framebuffer_config[1];
 
@@ -118,6 +120,7 @@ void PicaCore::ProcessCmdList(PAddr list, u32 size) {
 }
 
 void PicaCore::WriteInternalReg(u32 id, u32 value, u32 mask) {
+
     if (id >= RegsInternal::NUM_REGS) {
         LOG_ERROR(
             HW_GPU,
@@ -132,6 +135,10 @@ void PicaCore::WriteInternalReg(u32 id, u32 value, u32 mask) {
         0x00ffff00, 0x00ffffff, 0xff000000, 0xff0000ff, 0xff00ff00, 0xff00ffff,
         0xffff0000, 0xffff00ff, 0xffffff00, 0xffffffff,
     };
+
+    // If we're skipping this frame, only allow trigger IRQ
+    if (VideoCore::g_skip_frame && id != PICA_REG_INDEX(trigger_irq))
+        return;
 
     // TODO: Figure out how register masking acts on e.g. vs.uniform_setup.set_value
     const u32 old_value = regs.internal.reg_array[id];


### PR DESCRIPTION
I noticed you guys were looking at this in the past, so here is a "working" version.

It uses the same algorithm as it did years ago when it was first removed (we're talking Nov 2016) and therefore includes all the same issues. Seems to work better in OpenGL and won't render anything if set too high, but results may vary. Consider it unstable.

I mean seriously, it's super janky and probably won't work with the most popular games unless they were highly compatible with Citra in the first place. But when it does work, it's nice.

I did try to make an Android interface, but I'm not an Android programmer and I don't have a 64-bit device to run it on so I can't test/fix anything that might be wrong. It compiles, but that's all I can verify.

Anyway, do with it what you will.